### PR TITLE
feat(log): add log facade that allows to bind data values for json lo…

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ time.</p>
 <dt><a href="#MemLogger">MemLogger</a></dt>
 <dd><p>Logs messages to an in-memory buffer.</p>
 </dd>
+<dt><a href="#LogFacade">LogFacade</a></dt>
+<dd><p>Log facade that simplifies logging to a logger.</p>
+</dd>
 <dt><a href="#LogdnaLogger">LogdnaLogger</a></dt>
 <dd><p>Sends log messages to the logdna logging service.</p>
 <p>Log messages are sent immediately.</p>
@@ -95,6 +98,9 @@ rootLogger.loggers.set(&#39;default&#39;, new ConsoleLogger({level: &#39;debug&#
 <p>You should not log to the root logger directly; instead use one of the
 wrapper functions <code>log, fatal, err, warn, info, verbose, debug</code>; they
 perform some additional</p>
+</dd>
+<dt><a href="#rootFacade">rootFacade</a> : <code><a href="#LogFacade">LogFacade</a></code></dt>
+<dd><p>The root log facade that logs to the rootLogger.</p>
 </dd>
 <dt><a href="#JsonifyForLog">JsonifyForLog</a></dt>
 <dd><p>Trait used to serialize json objects to json. See jsonifyForLog.</p>
@@ -158,10 +164,6 @@ object generated.</p>
 default values.</p>
 <p>If the last object is an exception, it will be sent as { exception: $exception };
 this serves to facilitate searching for exceptions explicitly.</p>
-</dd>
-<dt><a href="#logWithOpts">logWithOpts(msg, opts)</a></dt>
-<dd><p>Lot to the root logger; this is a wrapper around <code>rootLogger.log</code>
-that handles exceptions thrown by rootLogger.log.</p>
 </dd>
 <dt><a href="#fatal">fatal(...msg)</a></dt>
 <dd><p>Uses the currently installed logger to print a fatal error-message</p>
@@ -723,6 +725,173 @@ still catch any errors and handle them appropriately.
 | msg | <code>Array</code> | The message; list of arguments as you would pass it to console.log |
 | opts | <code>Object</code> | – Configuration object; contains only one key at   the moment: `level` - The log level which can be one of `error, warn,   info, verbose` and `debug`. |
 
+<a name="LogFacade"></a>
+
+## LogFacade
+Log facade that simplifies logging to a logger.
+
+**Kind**: global class  
+
+* [LogFacade](#LogFacade)
+    * [new LogFacade(logger, [fields])](#new_LogFacade_new)
+    * [.data(fields)](#LogFacade+data) ⇒ [<code>LogFacade</code>](#LogFacade)
+    * [.child([fields])](#LogFacade+child) ⇒ [<code>LogFacade</code>](#LogFacade)
+    * [.logWithOpts(msg, opts)](#LogFacade+logWithOpts)
+    * [.fatal(...msg)](#LogFacade+fatal)
+    * [.error(...msg)](#LogFacade+error)
+    * [.warn(...msg)](#LogFacade+warn)
+    * [.info(...msg)](#LogFacade+info)
+    * [.log(...msg)](#LogFacade+log)
+    * [.verbose(...msg)](#LogFacade+verbose)
+    * [.debug(...msg)](#LogFacade+debug)
+    * [.trace(...msg)](#LogFacade+trace)
+    * [.silly(...msg)](#LogFacade+silly)
+
+<a name="new_LogFacade_new"></a>
+
+### new LogFacade(logger, [fields])
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| logger | [<code>Logger</code>](#Logger) |  | the logger to forward logging |
+| [fields] | <code>\*</code> | <code>{}</code> | optional data fields |
+
+<a name="LogFacade+data"></a>
+
+### logFacade.data(fields) ⇒ [<code>LogFacade</code>](#LogFacade)
+Sets data on this log facade.
+
+**Kind**: instance method of [<code>LogFacade</code>](#LogFacade)  
+**Returns**: [<code>LogFacade</code>](#LogFacade) - this  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| fields | <code>\*</code> | any properties |
+
+<a name="LogFacade+child"></a>
+
+### logFacade.child([fields]) ⇒ [<code>LogFacade</code>](#LogFacade)
+Creats a child log facade with bound data fields.
+
+**Kind**: instance method of [<code>LogFacade</code>](#LogFacade)  
+**Returns**: [<code>LogFacade</code>](#LogFacade) - - a new log facade  
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| [fields] | <code>\*</code> | <code>{}</code> | optional data fields |
+
+<a name="LogFacade+logWithOpts"></a>
+
+### logFacade.logWithOpts(msg, opts)
+Log to the logger; this is a wrapper around `this.logger.log`
+that handles exceptions thrown by logger.log.
+
+**Kind**: instance method of [<code>LogFacade</code>](#LogFacade)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| msg | <code>Array</code> | – The message as you would hand it to console.log |
+| opts | <code>Object</code> | – Any options you would pass to rootLogger.log |
+
+<a name="LogFacade+fatal"></a>
+
+### logFacade.fatal(...msg)
+Uses the currently installed logger to print a fatal error-message
+
+**Kind**: instance method of [<code>LogFacade</code>](#LogFacade)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| ...msg | <code>\*</code> | – The message as you would hand it to console.log |
+
+<a name="LogFacade+error"></a>
+
+### logFacade.error(...msg)
+Uses the currently installed logger to print an error message
+
+**Kind**: instance method of [<code>LogFacade</code>](#LogFacade)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| ...msg | <code>\*</code> | – The message as you would hand it to console.log |
+
+<a name="LogFacade+warn"></a>
+
+### logFacade.warn(...msg)
+Uses the currently installed logger to print a warn message
+
+**Kind**: instance method of [<code>LogFacade</code>](#LogFacade)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| ...msg | <code>\*</code> | – The message as you would hand it to console.log |
+
+<a name="LogFacade+info"></a>
+
+### logFacade.info(...msg)
+Uses the currently installed logger to print an info message
+
+**Kind**: instance method of [<code>LogFacade</code>](#LogFacade)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| ...msg | <code>\*</code> | – The message as you would hand it to console.log |
+
+<a name="LogFacade+log"></a>
+
+### logFacade.log(...msg)
+Uses the currently installed logger to print an info message
+
+**Kind**: instance method of [<code>LogFacade</code>](#LogFacade)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| ...msg | <code>\*</code> | – The message as you would hand it to console.log |
+
+<a name="LogFacade+verbose"></a>
+
+### logFacade.verbose(...msg)
+Uses the currently installed logger to print a verbose message
+
+**Kind**: instance method of [<code>LogFacade</code>](#LogFacade)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| ...msg | <code>\*</code> | – The message as you would hand it to console.log |
+
+<a name="LogFacade+debug"></a>
+
+### logFacade.debug(...msg)
+Uses the currently installed logger to print a debug message
+
+**Kind**: instance method of [<code>LogFacade</code>](#LogFacade)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| ...msg | <code>\*</code> | – The message as you would hand it to console.log |
+
+<a name="LogFacade+trace"></a>
+
+### logFacade.trace(...msg)
+Uses the currently installed logger to print a trace message
+
+**Kind**: instance method of [<code>LogFacade</code>](#LogFacade)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| ...msg | <code>\*</code> | – The message as you would hand it to console.log |
+
+<a name="LogFacade+silly"></a>
+
+### logFacade.silly(...msg)
+Uses the currently installed logger to print a silly message
+
+**Kind**: instance method of [<code>LogFacade</code>](#LogFacade)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| ...msg | <code>\*</code> | – The message as you would hand it to console.log |
+
 <a name="LogdnaLogger"></a>
 
 ## LogdnaLogger
@@ -842,6 +1011,12 @@ rootLogger.loggers.set('default', new ConsoleLogger({level: 'debug'}));
 You should not log to the root logger directly; instead use one of the
 wrapper functions `log, fatal, err, warn, info, verbose, debug`; they
 perform some additional
+
+**Kind**: global constant  
+<a name="rootFacade"></a>
+
+## rootFacade : [<code>LogFacade</code>](#LogFacade)
+The root log facade that logs to the rootLogger.
 
 **Kind**: global constant  
 <a name="JsonifyForLog"></a>
@@ -992,19 +1167,6 @@ this serves to facilitate searching for exceptions explicitly.
 | --- | --- | --- |
 | msg | <code>Array</code> | – Parameters as you would pass them to console.log |
 | opts | <code>Object</code> | – Parameters are forwarded to serializeMessage; other than that:   - level: one of the log levels; this parameter is required. |
-
-<a name="logWithOpts"></a>
-
-## logWithOpts(msg, opts)
-Lot to the root logger; this is a wrapper around `rootLogger.log`
-that handles exceptions thrown by rootLogger.log.
-
-**Kind**: global function  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| msg | <code>Array</code> | – The message as you would hand it to console.log |
-| opts | <code>Object</code> | – Any options you would pass to rootLogger.log |
 
 <a name="fatal"></a>
 

--- a/test/logfacade.test.js
+++ b/test/logfacade.test.js
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2019 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+
+const assert = require('assert');
+const { join } = require('ferrum');
+const {
+  MemLogger, LogFacade, messageFormatJson,
+} = require('../src/log');
+
+const cleanTimestamp = (buf) => {
+  buf.forEach((msg) => {
+    // eslint-disable-next-line no-param-reassign
+    delete msg.timestamp;
+  });
+  return buf;
+};
+
+describe('LogFacade', () => {
+  it('logs', () => {
+    const logger = new MemLogger({ level: 'silly' });
+    const log = new LogFacade(logger);
+    log.silly('silly', 0);
+    log.trace('trace', 1);
+    log.debug('debug', 2);
+    log.verbose('verbose', 3);
+    log.info('info', 4);
+    log.warn('warn', 5);
+    log.error('error', 6);
+    log.fatal('fatal', 7);
+    assert.strictEqual(`${join(logger.buf, '\n')}`, '[SILLY] silly 0\n[TRACE] trace 1\n[DEBUG] debug 2\n[VERBOSE] verbose 3\n[INFO] info 4\n[WARN] warn 5\n[ERROR] error 6\n[FATAL] fatal 7');
+  });
+
+  it('does not log data', () => {
+    const logger = new MemLogger({ level: 'silly' });
+    const log = new LogFacade(logger, { foo: 42 });
+    log.debug('debug', 0);
+    assert.strictEqual(`${join(logger.buf, '\n')}`, '[DEBUG] debug 0');
+  });
+
+  it('logs data with the json format', () => {
+    const logger = new MemLogger({
+      level: 'silly',
+      formatter: messageFormatJson,
+    });
+    const log = new LogFacade(logger, { foo: 42 });
+    log.debug('debug', 0);
+
+    const out = cleanTimestamp(logger.buf);
+    assert.deepEqual(out, [{
+      foo: 42,
+      level: 'debug',
+      message: 'debug 0',
+    }]);
+  });
+
+  it('can change the data', () => {
+    const logger = new MemLogger({
+      level: 'silly',
+      formatter: messageFormatJson,
+    });
+    const log = new LogFacade(logger, { foo: 42 });
+    log.debug('debug', 0);
+    log.data({
+      foo: 'new value',
+    });
+    log.debug('debug', 0);
+
+    const out = cleanTimestamp(logger.buf);
+    assert.deepEqual(out, [{
+      foo: 42,
+      level: 'debug',
+      message: 'debug 0',
+    }, {
+      foo: 'new value',
+      level: 'debug',
+      message: 'debug 0',
+    }]);
+  });
+
+  it('can create child loggers data with the json format', () => {
+    const logger = new MemLogger({
+      level: 'silly',
+      formatter: messageFormatJson,
+    });
+    const log = new LogFacade(logger, { foo: 'base', bar: 42 });
+    log.debug('debug', 0);
+    const c = log.child({
+      test: 'hello',
+      foo: 'override',
+    });
+    c.debug('child logger');
+    log.debug('original logger');
+
+    const out = cleanTimestamp(logger.buf);
+    assert.deepEqual(out, [{
+      bar: 42,
+      foo: 'base',
+      level: 'debug',
+      message: 'debug 0',
+    }, {
+      bar: 42,
+      foo: 'override',
+      level: 'debug',
+      message: 'child logger',
+      test: 'hello',
+    }, {
+      bar: 42,
+      foo: 'base',
+      level: 'debug',
+      message: 'original logger',
+    }]);
+  });
+});


### PR DESCRIPTION
…gging

fixes #34, fixes #26

also see #30 

---

@koraa see my idea for a `LogFacade` that can have bound fields what could be propagated to the json format. I tried to keep the original code as untouched as possible.

however, I think it would benefit from a refactor if we could split the message formatting form the logging (as noted in #30).