### PR TITLE
feat: Increase resolution of timestamps to nanoseconds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -101,9 +101,9 @@
       "dev": true
     },
     "@babel/runtime": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.3.tgz",
-      "integrity": "sha512-kq6anf9JGjW8Nt5rYfEuGRaEAaH1mkv3Bbu6rYvLOpPh/RusSJXuKPEAoZ7L7gybZkchE8+NV5g9vKF4AGAtsA==",
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.2.tgz",
+      "integrity": "sha512-JONRbXbTXc9WQE2mAZd1p0Z3DZ/6vaQIkgYMSTP3KjRCyd7rCZCcfhCyX+YjwcKxcZ82UrxbRD358bpExNgrjw==",
       "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.2"
@@ -206,25 +206,25 @@
       }
     },
     "@octokit/endpoint": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-5.5.0.tgz",
-      "integrity": "sha512-TXYS6zXeBImNB9BVj+LneMDqXX+H0exkOpyXobvp92O3B1348QsKnNioISFKgOMsb3ibZvQGwCdpiwQd3KAjIA==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-5.5.1.tgz",
+      "integrity": "sha512-nBFhRUb5YzVTCX/iAK1MgQ4uWo89Gu0TH00qQHoYRCsE12dWcG1OiLd7v2EIo2+tpUKPMOQ62QFy9hy9Vg2ULg==",
       "dev": true,
       "requires": {
-        "@octokit/types": "^1.0.0",
+        "@octokit/types": "^2.0.0",
         "is-plain-object": "^3.0.0",
         "universal-user-agent": "^4.0.0"
       }
     },
     "@octokit/request": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.3.0.tgz",
-      "integrity": "sha512-mMIeNrtYyNEIYNsKivDyUAukBkw0M5ckyJX56xoFRXSasDPCloIXaQOnaKNopzQ8dIOvpdq1ma8gmrS+h6O2OQ==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.3.1.tgz",
+      "integrity": "sha512-5/X0AL1ZgoU32fAepTfEoggFinO3rxsMLtzhlUX+RctLrusn/CApJuGFCd0v7GMFhF+8UiCsTTfsu7Fh1HnEJg==",
       "dev": true,
       "requires": {
         "@octokit/endpoint": "^5.5.0",
         "@octokit/request-error": "^1.0.1",
-        "@octokit/types": "^1.0.0",
+        "@octokit/types": "^2.0.0",
         "deprecation": "^2.0.0",
         "is-plain-object": "^3.0.0",
         "node-fetch": "^2.3.0",
@@ -233,19 +233,20 @@
       }
     },
     "@octokit/request-error": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-1.0.4.tgz",
-      "integrity": "sha512-L4JaJDXn8SGT+5G0uX79rZLv0MNJmfGa4vb4vy1NnpjSnWDLJRy6m90udGwvMmavwsStgbv2QNkPzzTCMmL+ig==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-1.2.0.tgz",
+      "integrity": "sha512-DNBhROBYjjV/I9n7A8kVkmQNkqFAMem90dSxqvPq57e2hBr7mNTX98y3R2zDpqMQHVRpBDjsvsfIGgBzy+4PAg==",
       "dev": true,
       "requires": {
+        "@octokit/types": "^2.0.0",
         "deprecation": "^2.0.0",
         "once": "^1.4.0"
       }
     },
     "@octokit/rest": {
-      "version": "16.34.0",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.34.0.tgz",
-      "integrity": "sha512-EBe5qMQQOZRuezahWCXCnSe0J6tAqrW2hrEH9U8esXzKor1+HUDf8jgImaZf5lkTyWCQA296x9kAH5c0pxEgVQ==",
+      "version": "16.34.1",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.34.1.tgz",
+      "integrity": "sha512-JUoS12cdktf1fv86rgrjC/RvYLuL+o7p57W7zX1x7ANFJ7OvdV8emvUNkFlcidEaOkYrxK3SoWgQFt3FhNmabA==",
       "dev": true,
       "requires": {
         "@octokit/request": "^5.2.0",
@@ -263,20 +264,12 @@
       }
     },
     "@octokit/types": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-1.1.0.tgz",
-      "integrity": "sha512-t4ZD74UnNVMq6kZBDZceflRKK3q4o5PoCKMAGht0RK84W57tqonqKL3vCxJHtbGExdan9RwV8r7VJBZxIM1O7Q==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.0.1.tgz",
+      "integrity": "sha512-YDYgV6nCzdGdOm7wy43Ce8SQ3M5DMKegB8E5sTB/1xrxOdo2yS/KgUgML2N2ZGD621mkbdrAglwTyA4NDOlFFA==",
       "dev": true,
       "requires": {
-        "@types/node": "^12.11.1"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "12.11.7",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.11.7.tgz",
-          "integrity": "sha512-JNbGaHFCLwgHn/iCckiGSOZ1XYHsKFwREtzPwSGCVld1SGhOlmZw2D4ZI94HQCrBHbADzW9m4LER/8olJTRGHA==",
-          "dev": true
-        }
+        "@types/node": ">= 8"
       }
     },
     "@polka/url": {
@@ -297,14 +290,14 @@
       }
     },
     "@semantic-release/commit-analyzer": {
-      "version": "6.3.2",
-      "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-6.3.2.tgz",
-      "integrity": "sha512-TezpOODuMcdDuGcGsI2QRqkH3sT7ffhsxid9J8OyspXDe8E4tshekJESJ6Pq8jTrggluKd3tCK26Vsyu6SkeSg==",
+      "version": "6.3.3",
+      "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-6.3.3.tgz",
+      "integrity": "sha512-Pyv1ZL2u5AIOY4YbxFCAB5J1PEh5yON8ylbfiPiriDGGW6Uu1U3Y8lysMtWu+FUD5x7tSnyIzhqx0+fxPxqbgw==",
       "dev": true,
       "requires": {
         "conventional-changelog-angular": "^5.0.0",
         "conventional-commits-filter": "^2.0.0",
-        "conventional-commits-parser": "^3.0.0",
+        "conventional-commits-parser": "^3.0.7",
         "debug": "^4.0.0",
         "import-from": "^3.0.0",
         "lodash": "^4.17.4"
@@ -1156,6 +1149,11 @@
       "integrity": "sha512-IWIbu7pMqyw3EAJHzzHbWa85b6oud/yfKYg5rqB5hNE8CeMi3nX+2C2sj0HswfblST86hpVEOAb9x34NZd6P7A==",
       "dev": true
     },
+    "big.js": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
+      "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
+    },
     "bluebird": {
       "version": "3.5.5",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
@@ -1661,14 +1659,14 @@
       }
     },
     "conventional-commits-parser": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.0.5.tgz",
-      "integrity": "sha512-qVz9+5JwdJzsbt7JbJ6P7NOXBGt8CyLFJYSjKAuPSgO+5UGfcsbk9EMR+lI8Unlvx6qwIc2YDJlrGIfay2ehNA==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.0.7.tgz",
+      "integrity": "sha512-4mx/FRC92z0yIiXGyRVYQFhn0jWDwvxnj2UuLaUi3hJSG4Thall6GXA8YOPHQK2qvotciJandJIVmuSvLgDLbQ==",
       "dev": true,
       "requires": {
         "JSONStream": "^1.0.4",
-        "is-text-path": "^2.0.0",
-        "lodash": "^4.2.1",
+        "is-text-path": "^1.0.1",
+        "lodash": "^4.17.15",
         "meow": "^4.0.0",
         "split2": "^2.0.0",
         "through2": "^3.0.0",
@@ -3559,12 +3557,12 @@
       }
     },
     "is-text-path": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-2.0.0.tgz",
-      "integrity": "sha512-+oDTluR6WEjdXEJMnC2z6A4FRwFoYuvShVVEGsS7ewc0UTi2QtAKMDJuL4BDEVt+5T7MjFo12RP8ghOM75oKJw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-1.0.1.tgz",
+      "integrity": "sha1-Thqg+1G/vLPpJogAE5cgLBd1tm4=",
       "dev": true,
       "requires": {
-        "text-extensions": "^2.0.0"
+        "text-extensions": "^1.0.0"
       }
     },
     "is-wsl": {
@@ -4929,9 +4927,9 @@
       "dev": true
     },
     "npm": {
-      "version": "6.12.1",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-6.12.1.tgz",
-      "integrity": "sha512-+pMvUpgSXVBythrv//64j4i6DaLLJ1O0y8kwjNgjAE7atBNGzX4rcOEWvmsuiei6J+mA38O0nUZ/P35GuCD/jg==",
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-6.13.0.tgz",
+      "integrity": "sha512-zjSJ8zjk0cDBZXqTWbQ6+qOdm1m2k489YDFP60RQRUhOxT5LOBhl+cDtFlEXEIblcNjofmsZ/qQ/wzmn5frimQ==",
       "dev": true,
       "requires": {
         "JSONStream": "^1.3.5",
@@ -5019,14 +5017,14 @@
         "once": "~1.4.0",
         "opener": "^1.5.1",
         "osenv": "^0.1.5",
-        "pacote": "^9.5.8",
+        "pacote": "^9.5.9",
         "path-is-inside": "~1.0.2",
         "promise-inflight": "~1.0.1",
         "qrcode-terminal": "^0.12.0",
         "query-string": "^6.8.2",
         "qw": "~1.0.1",
         "read": "~1.0.7",
-        "read-cmd-shim": "^1.0.4",
+        "read-cmd-shim": "^1.0.5",
         "read-installed": "~4.0.3",
         "read-package-json": "^2.1.0",
         "read-package-tree": "^5.3.1",
@@ -7291,7 +7289,7 @@
           }
         },
         "pacote": {
-          "version": "9.5.8",
+          "version": "9.5.9",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -7327,7 +7325,7 @@
           },
           "dependencies": {
             "minipass": {
-              "version": "2.3.5",
+              "version": "2.9.0",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -7560,7 +7558,7 @@
           }
         },
         "read-cmd-shim": {
-          "version": "1.0.4",
+          "version": "1.0.5",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -8862,9 +8860,9 @@
       "dev": true
     },
     "p-retry": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.1.0.tgz",
-      "integrity": "sha512-oepllyG9gX1qH4Sm20YAKxg1GA7L7puhvGnTfimi31P07zSIj7SDV6YtuAx9nbJF51DES+2CIIRkXs8GKqWJxA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.2.0.tgz",
+      "integrity": "sha512-jPH38/MRh263KKcq0wBNOGFJbm+U6784RilTmHjB/HM9kH9V8WlCpVUcdOmip9cjXOh6MxZ5yk1z2SjDUJfWmA==",
       "dev": true,
       "requires": {
         "@types/retry": "^0.12.0",
@@ -9011,9 +9009,9 @@
       }
     },
     "picomatch": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.0.7.tgz",
-      "integrity": "sha512-oLHIdio3tZ0qH76NybpeneBhYVj0QFTfXEFTc/B3zKQspYfYYkWYgFsmzo+4kvId/bQRcNkVeguI3y+CD22BtA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.1.1.tgz",
+      "integrity": "sha512-OYMyqkKzK7blWO/+XZYP6w8hH0LDvkBvdvKukti+7kqYFCiEAk+gI3DWnryapc0Dau05ugGTy0foQ6mqn4AHYA==",
       "dev": true
     },
     "pify": {
@@ -11102,9 +11100,9 @@
       }
     },
     "text-extensions": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-2.0.0.tgz",
-      "integrity": "sha512-F91ZqLgvi1E0PdvmxMgp+gcf6q8fMH7mhdwWfzXnl1k+GbpQDmi8l7DzLC5JTASKbwpY3TfxajAUzAXcv2NmsQ==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.9.0.tgz",
+      "integrity": "sha512-wiBrwC1EhBelW12Zy26JeOUkQ5mRu+5o8rpsJk5+2t+Y5vE7e842qtZDQ2g1NpX/29HdyFeJ4nSIhI47ENSxlQ==",
       "dev": true
     },
     "text-table": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "homepage": "https://github.com/adobe/helix-log#readme",
   "dependencies": {
+    "big.js": "^5.2.2",
     "colorette": "^1.1.0",
     "ferrum": "^1.4.1",
     "phin": "^3.4.0",

--- a/src/big-date.js
+++ b/src/big-date.js
@@ -1,0 +1,427 @@
+/*
+ * Copyright 2019 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+const { max, floor, abs } = Math;
+const { inspect } = require('util');
+const { hrtime } = require('process');
+const Big = require('big.js');
+const {
+  size, type, typename, join, take, repeat,
+  Shallowclone, Deepclone, Equals,
+} = require('ferrum');
+
+// Here we calculate the offset between a hrtime() derived epoch
+// and a new Date() derived one. This will allow us to derive the
+// epoch/unix time easily from the high resolution clock.
+// This method can introduce an error of +-1ms when looking just
+// at the millisecond portion of the time; we could eliminate this
+// error by waiting for the Date based epoch to be incremented and
+// measuring the hrtime offset at this point, but it's not worth
+// the effort.
+const _calcHrtimeOff = () => {
+  // Low latency portion
+  const h = hrtime(); // hrtime first because date has more overhead
+  const d = new Date();
+  // Low latency portion end
+
+  // Parse date
+  const dateMs = d.getTime();
+
+  // Parse hrtime
+  const hrtimeMs = h[0] * 1e3 + floor(h[1] / 1e6);
+  const hrtimeNs = h[1] % 1e6;
+
+  return [(dateMs - hrtimeMs), hrtimeNs];
+};
+
+let _hrtimeOffset = _calcHrtimeOff();
+
+/**
+ * A Date class capable of storing timestamps at arbitrary precisions that can
+ * be used as a drop-in replacement for date.
+ *
+ * When generating timestamps at quick succession `Date` will often yield the
+ * same result:
+ *
+ * ```js
+ * const assert = require('assert');
+ * const a = new Date();
+ * const b = new Date();
+ * assert.strictEqual(a.toISOString(), b.toISOString())
+ * ```
+ *
+ * This is often problematic. E.g. in the case of helix-log this can lead to log
+ * messages being displayed out of order. Using `process.hrtime()` is not an option
+ * either because it's time stamps are only really valid on the same process.
+ *
+ * In order to remedy this problem, helix-log was created: It measures time at a very
+ * high precision (nano seconds) while maintaining a reference to corordinated universal time
+ *
+ * ```js
+ * const assert = require('assert');
+ * const { BigDate } = require('@adobe/helixLog')
+ * const a = new BigDate();
+ * const b = new BigDate();
+ * assert.notStrictEqual(a.toISOString(), b.toISOString());
+ * ```
+ *
+ * # Precision in relation to Corordinated Universal Time
+ *
+ * Mostly depends on how well synchronized the system clock is…usually between 20ms and 200ms.
+ * This goes for both Date as well as BigDate, although BigDate can add up to 1ms of extra error.
+ *
+ * # Precision in relation to Date
+ *
+ * BigDate can add up to 1ms out of sync with Date.
+ *
+ * When measuring comparing `BigDate.preciseTime()` and `Date.getTime()` you may
+ * find differences of up to 2.5ms due to the imprecision of measurement.
+ *
+ * # Precision in relation to hrtime()
+ *
+ * Using BigDate::fromHrtime() you can convert hrtime timestamps to BigDate.
+ * The conversion should be 1 to 1 (BigDate uses hrtime internally), but the
+ * internal reference will be recalculated every time the clock jumps (e.g on
+ * hibernation or when the administrator adjusts the time). This can lead to
+ * fromHrtime interpreting timestamps vastly different before and after the jump.
+ *
+ * # For benchmarking/measurement overhead
+ *
+ * BigDate can be used for benchmarking and is better at it than Date and worse at it than hrtime.
+ *
+ * Measuring the actual overhead proofed difficult, because results where vastly different
+ * depending on how often hrtime was called.
+ *
+ *          | Worst | Cold  |  Hot  | Best
+ * -------- | ----- | ----- | ----- | -----
+ * Hrtime   |  10µs | 20µs  | 1.5µs |  80ns
+ * BigDate  | 500µs | 80µs  |   4µs | 250ns
+ *
+ * Worst: First few invocations, bad luck
+ * Cold: Typical first few invocations.
+ * Hot: After tens to hundreds of invocations
+ * Best: After millions of invocations
+ *
+ * @class
+ * @implements Equals
+ * @implements Deepclone
+ * @implements Shallowclone
+ *
+ * @constructor
+ * The default constructor can be used to get the current point in time as a BigDate.
+ *
+ * @constructor
+ * @param {Date|BigDate} Converts a Date to a BigDate or copies a BigDate
+ *
+ * @constructor
+ * @param {String} Construct a BigDate from a string (like date, but supports arbitrary
+ *   precision in the ISO 8601 String decimal places)
+ *
+ * @constructor
+ * @param {Number|Big|Bigint} Construct a BigDate from the epoch value (unix time/number of
+ *   milliseconds elapsed sinc 1970-01-01). Decimal places are honored and can be used to
+ *   supply an epoch value of arbitrary precision.
+ *
+ * @constructor
+ * @param {...*} Can be used to construct a BigDate from components (year, month, day, hours,
+ *   minutes, seconds, milliseconds with decimal places)
+ */
+class BigDate extends Date {
+  /**
+   * The nanosecond component not stored by the Date base.
+   *
+   * @private
+   * @member {Number|Big} _frac
+   */
+
+  constructor(v) {
+    // The following code has been optimized in order to
+    // reduce the overhead when using BigDate to actually
+    // measure time both when the code is hot (invoked many times)
+    // and when cold (invoked very few times).
+    //
+    // Optimization measures taken:
+    // - Use `arguments` (down below) instead of declaring variadic args in the constructor
+    // - Avoid double initialization (all the init functions initialize the underlying
+    //   Date empty and later set all values. Here we directly use super for initialization)
+    // - Avoid calling methods/manual unlinking (not benchmarked! We may yet decide to move the
+    //   math portion to it's own function so we can avoid the triple code duplication we end
+    //   up with in here).
+    // - Forgoing the use of `Big` for calculations; instead we use math with two-tuples of [ms, ns]
+    //   all complete with fully manual addition overflow handling
+    // - Using a native Number for _hrtime instead of converting to `Big` (this means _hrtime can
+    //   contain multiple types).
+    //
+    // These optimization *have* been evaluated using benchmarks. When modifying
+    // this class further benchmarking it is *highly* recommended. I suggest
+    // measuring the time stamping overhead:
+    //
+    // ```
+    // const a = hrtime.bigint();
+    // const b = hrtime.bigint();
+    // return b - a;
+    // ```
+    //
+    // Execute many thousands of times, discard the first 10000 and average the rest.
+    //
+    // ```
+    // const a = hrtime.bigint();
+    // const _ = new BigInt();
+    // const b = hrtime.bigint();
+    // return b - a;
+    // ```
+    //
+    // Execute many thousands of times; average separately the results after different iteration
+    // numbers and subtract the measured hrtime latency.
+    //
+    // Average separately:
+    //
+    // - Run 1
+    // - Run 2
+    // - Run 3,4,5
+    // - Run 6-10
+    // - Run 11-100
+    // - Run 101-1000
+    // - Run 1001-10000
+    // - Run 10001-100000
+    // - Run 100001-1e6
+    //
+    // These different measurements should give insight into how the v8 optimization kicks in as
+    // this becomes hotter.
+    //
+    // The entire measurement must be executed multiple times (including a full process restart) and
+    // then combined.
+    //
+    // ## Second methodology:
+    //
+    // ```
+    // const a = new BigDate();
+    // const b = new BigDate();
+    // return b.preciseTime().sub(b.preciseTime());
+    // ```
+    //
+    // This methodology does not require measuring hrtime latency. All other steps are the same.
+    //
+    // Optimally you would collect data using both methodologies (in separate process starts).
+
+    // FAST PATH START
+    if (v === undefined) {
+      const h = hrtime();
+      const ref = new Date(); // For detecting clock jumps
+
+      let ms = h[0] * 1e3 + floor(h[1] / 1e6);
+      let ns = h[1] % 1e6;
+
+      // Two component subtraction with manual overflow
+      ms += _hrtimeOffset[0];
+      ns += _hrtimeOffset[1];
+      /* istanbul ignore next */
+      if (ns > 1e6) {
+        ms += 1;
+        ns %= 1e6;
+      }
+
+      super(ms);
+      this._frac = ns;
+
+      // Detected clock jump! Need to recalculate offset
+      /* istanbul ignore next */
+      if (/* unlikely */ abs(ref.getTime() - this.getTime()) > 2.5) {
+        // This code block is still optimized but no longer really part
+        // of the fast path as this is only executed after a clock jump (admin
+        // adjusts time/hibernation/suspend).
+        _hrtimeOffset = _calcHrtimeOff();
+
+        ms = h[0] * 1e3 + floor(h[1] / 1e6);
+        ns = h[1] % 1e6;
+
+        // Two component subtraction with manual overflow
+        ms += _hrtimeOffset[0];
+        ns += _hrtimeOffset[1];
+        /* istanbul ignore next */
+        if (ns > 1e6) {
+          ms += 1;
+          ns %= 1e6;
+        }
+
+        this.setTime(ms);
+        this._frac = ns;
+      }
+
+      return;
+    }
+    // FAST PATH END
+
+
+    super(0);
+    if (arguments.length > 1) {
+      // eslint-disable-next-line prefer-rest-params
+      this._initComponents(...arguments);
+    } else if (v instanceof Date) {
+      // Converting to a string first because this will work even with
+      // multiple instances of the BigDate type (package loaded multiple times).
+      this._initString(v.toISOString());
+    } else if (type(v) === String) {
+      this._initString(v);
+    } else {
+      // We just assume this must be initialization from milliseconds
+      // if it is not other mode of initialization. This approach also
+      // allows for other instances of the Big type (same package loaded
+      // multiple times)
+      this._initMillis(v);
+    }
+  }
+
+  /**
+   * Convert the return value of `hrtime` to BigDate.
+   *
+   * See the caveats in the class documentation.
+   *
+   * @method
+   * @param {Array|BigInt}
+   */
+  static fromHrtime(hr) {
+    const r = new BigDate(); // Trigger a offset recalculation if necessary
+
+    const off = Big(_hrtimeOffset[1]).mul(1e-6).plus(_hrtimeOffset[0]);
+    /* istanbul ignore next */
+    const ms = type(hr) !== Array
+      ? Big(hr).mul(1e-6)
+      : Big(hr[0] * 1e3).plus(Big(hr[1]).mul(1e-6));
+
+    r.setPreciseTime(ms.plus(off));
+    return r;
+  }
+
+  _initFields(date, frac) {
+    this.setTime(date);
+    this._frac = frac;
+  }
+
+  _initComponents(...args) {
+    if (args.length < 7) {
+      this._initDate(new Date(...args));
+    } else {
+      const ns = Big(args[6]).mul(1e6).mod(1e6);
+      // eslint-disable-next-line no-param-reassign
+      args[6] = Number(args[6]);
+      this._initFields(new Date(...args), ns);
+    }
+  }
+
+  _initDate(orig) {
+    this._initFields(orig, 0);
+  }
+
+  _initMillis(ms) {
+    this._initFields(
+      new Date(Number(ms)),
+      Big(ms).mul(1e6).mod(1e6),
+    );
+  }
+
+  _initString(s) {
+    const s_ = String(s);
+    const d = new Date(s_);
+
+    // Extract the number of seconds with decimal places;
+    // this assumes the string is an ISO 8601 date with sub-seconds.
+    // If the regexp search failed, = then we just use the date.
+    const [_a, secLit] = s_.match(/:(\d{1,2}\.\d*)(Z|[+-]\d+)?$/) || [];
+    /* istanbul ignore next */
+    if (!secLit) {
+      return this._initDate(d);
+    }
+
+    return this._initFields(d, Big(secLit).mul(1e9).mod(1e6));
+  }
+
+  /**
+   * Get the Date as the epoch value. (Unix time/Number of seconds since 2019-01-01 UTC):
+   * @method
+   * @returns {Big} By returning a big decimal this can contain decimal places and support
+   *   arbitrary precision.
+   */
+  preciseTime() {
+    return Big(this._frac).mul(1e-6).plus(super.getTime());
+  }
+
+  /**
+   * Set the date as the epoch value.
+   *
+   * @method
+   * @param {Big}
+   */
+  setPreciseTime(n) {
+    this._initMillis(n);
+  }
+
+  /**
+   * Get the precise time from a Date or BigDate.
+   *
+   * @static
+   * @returns {Big}
+   */
+  static preciseTime(d) {
+    // Again, trying to stay compatible in the face of multiple instanciations
+    // of this class again.
+    return type(d.preciseTime) === Function
+      ? Big(d.preciseTime())
+      : Big(d.getTime());
+  }
+
+  /**
+   * Convert the Date to ISO 8601 format.
+   *
+   * This changes the behaviour; in Date the number of decimal places
+   * is limited to 3 and padded to 3 (milliseconds); in BigDecimal
+   * the number of decimal places is unlimited and padded to 9 (nanoseconds).
+   *
+   * @method
+   * @override
+   * @returns {String}
+   */
+  toISOString() {
+    const iso = super.toISOString();
+
+    // Extract the decimals string from the precise time
+    const decimals = String(this.preciseTime().mul(1e-3)).replace(/^[^.]+./, '');
+
+    // Generate a padding (we want at least three decimal places)
+    const pad = join('')(take(repeat('0'), max(0, 9 - size(decimals))));
+
+    // Replace the decimal places in the iso string
+    return iso.replace(/\.\d+/, `.${decimals}${pad}`);
+  }
+
+  toJSON() {
+    return this.toISOString();
+  }
+
+  [inspect.custom](depth, opts) {
+    const s = `${typename(type(this))} ${this.toISOString()}`;
+    return opts.stylize(s, 'date');
+  }
+
+  [Equals.sym](otr) {
+    return this.toISOString() === new BigDate(otr).toISOString();
+  }
+
+  [Deepclone.sym]() {
+    return new BigDate(this);
+  }
+
+  [Shallowclone.sym]() {
+    return new BigDate(this);
+  }
+}
+
+module.exports = { BigDate };

--- a/src/coralogix.js
+++ b/src/coralogix.js
@@ -15,6 +15,7 @@ const { hostname } = require('os');
 const path = require('path');
 const phin = require('phin');
 const { messageFormatJsonString, FormattedLoggerBase } = require('./log');
+const { BigDate } = require('./big-date');
 const { Secret } = require('./secret');
 
 const _logLevelMapping = {
@@ -116,7 +117,7 @@ class CoralogixLogger extends FormattedLoggerBase {
         subsystemName: this.subsystem,
         computerName: this.host,
         logEntries: [{
-          timestamp: fields.timestamp.getTime(),
+          timestamp: Number(BigDate.preciseTime(fields.timestamp)),
           text: payload,
           severity: _logLevelMapping[fields.level],
         }],

--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,7 @@ const { exec, isdef } = require('ferrum');
 const pkgJson = require('../package.json');
 
 module.exports = {
+  ...require('./big-date'),
   ...require('./recording'),
   ...require('./log'),
   ...require('./serialize-json'),

--- a/src/serialize-json.js
+++ b/src/serialize-json.js
@@ -75,8 +75,12 @@ JsonifyForLog.implWild((wild) => {
 });
 // Fallback exporter
 JsonifyForLog.implWild(() => (what) => {
-  const o = jsonifyForLog(obj(Object.entries(what)));
-  return { $type: typename(type(what)), ...o };
+  if (type(what.toJSON) === Function) {
+    return what.toJSON();
+  } else {
+    const o = jsonifyForLog(obj(Object.entries(what)));
+    return { $type: typename(type(what)), ...o };
+  }
 });
 
 module.exports = { jsonifyForLog, JsonifyForLog };

--- a/test/big-date.js
+++ b/test/big-date.js
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2019 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+
+const { inspect } = require('util');
+const { hrtime } = require('process');
+const assert = require('assert');
+const Big = require('big.js');
+const {
+  each, range0, assertUneq, shallowclone, deepclone,
+} = require('ferrum');
+const {
+  BigDate, _bigFloor, _bigDecimalPlaces, jsonifyForLog,
+} = require('../src');
+const { ckEq } = require('./util');
+
+describe('BigDate', () => {
+  describe('construction, toISOString(), preciseTime()', () => {
+    const ck = (what, iso, time, ...args) => {
+      it(what, () => {
+        const d = new BigDate(...args);
+        ckEq(d.toISOString(), iso);
+        assert(d.preciseTime().eq(time));
+      });
+    };
+
+    const iso = '9051-01-24T10:22:25.678Z';
+    const isoLong = '9051-01-24T10:22:25.678000000Z';
+    const nonUTCIso = '9051-01-24T18:22:25.678+0800';
+    const millis = 223456789345678;
+
+    const bigISO = '1970-01-01T00:00:00.9872345678902345678Z';
+    const bigMillis = Big('987.2345678902345678');
+
+    ck('from Millis', isoLong, millis, millis);
+    ck('from Big Millis', bigISO, bigMillis, bigMillis);
+
+    ck('from ISO', isoLong, millis, iso);
+    ck('from ISO 2', isoLong, millis, isoLong);
+    ck('from Big ISO', bigISO, bigMillis, bigISO);
+    ck('from Non UTC ISO', isoLong, millis, nonUTCIso);
+
+    ck('from Date', isoLong, millis, new Date(millis));
+    ck('from Big Date', bigISO, bigMillis, new BigDate(bigMillis));
+
+    const d = new Date(millis);
+    ck('from components', isoLong, millis,
+      d.getFullYear(), d.getMonth(), d.getDate(),
+      d.getHours(), d.getMinutes(), d.getSeconds(),
+      d.getMilliseconds());
+
+    ck('from sparse components', '2019-01-31T23:00:00.000000000Z', 1548975600000, 2019, 1);
+
+    const bd = new BigDate(bigMillis);
+    ck('from Big components', bigISO, bigMillis,
+      bd.getFullYear(), bd.getMonth(), bd.getDate(),
+      bd.getHours(), bd.getMinutes(), bd.getSeconds(),
+      bd.preciseTime().mod(1000));
+
+    const ckFromHrtime = (hr) => {
+      const ref = new BigDate();
+      const actual = BigDate.fromHrtime(hr);
+      assert(ref.preciseTime().sub(actual.preciseTime()).lt(1));
+    };
+
+    it('fromHrtime', () => ckFromHrtime(hrtime()));
+
+    if (hrtime.bigint) {
+      it('fromHrtime with BigInt', () => ckFromHrtime(hrtime.bigint()));
+    }
+  });
+
+  describe('static preciseTime', () => {
+    it('with Date', () => {
+      const v = BigDate.preciseTime(new Date(300));
+      assert(v instanceof Big);
+      assert(v.eq(300));
+    });
+
+    it('with BigDate', () => {
+      const v = BigDate.preciseTime(new BigDate(Big('4.8371923798217')));
+      assert(v instanceof Big);
+      assert(v.eq('4.8371923798217'));
+    });
+  });
+
+  describe('measures time', () => {
+    it('Relative to Date', () => {
+      each(range0(100), () => {
+        const a = new Date();
+        const b = new BigDate();
+        assert(b.preciseTime().sub(a.getTime()).abs().lt(4));
+      });
+    });
+
+    it('increasing steadily', () => {
+      let prev = new BigDate().preciseTime();
+      each(range0(100), () => {
+        const cur = new BigDate().preciseTime();
+        assert(cur.sub(prev).lt(500));
+        assert(cur.gt(prev));
+        prev = cur;
+      });
+    });
+
+    it('sleep reference', async () => {
+      const d0 = new BigDate();
+      await new Promise((res) => setTimeout(res, 5));
+      const d1 = new BigDate();
+      const tdiff = d1.preciseTime().sub(d0.preciseTime());
+      assert(tdiff.gte(5));
+      assert(tdiff.lt(10));
+    });
+  });
+
+  it('setPreciseTime()', () => {
+    const t = 1234567.1123456;
+    const a = new BigDate(t);
+    const b = new BigDate();
+    assertUneq(a, b);
+    b.setPreciseTime(t);
+    ckEq(a, b);
+  });
+
+  describe('converts to json with high precision', () => {
+    const iso = '2019-11-07T17:25:20.293179804Z';
+    const res = `"${iso}"`;
+    const d = new BigDate(iso);
+    it('JSON.stringify', () => ckEq(JSON.stringify(d), res));
+    it('jsonifyForLog', () => ckEq(JSON.stringify(jsonifyForLog(d)), res));
+  });
+
+  it('inspect()', () => {
+    const iso = '2019-11-07T17:25:20.293179804333Z';
+    ckEq(inspect(new BigDate(iso)), `BigDate ${iso}`);
+  });
+
+  it('toString()', () => {
+    const d = new BigDate();
+    ckEq(String(d), String(new Date(d)));
+  });
+
+  describe('implements Interfaces', () => {
+    it('Equals', () => {
+      const a = new BigDate(Big('1234567.1123456'));
+      const b = new BigDate(Big('1234568.1123456'));
+      const c = new BigDate(Big('1234567.1123451'));
+      ckEq(a, new BigDate(a));
+      assertUneq(a, b);
+      assertUneq(a, c);
+    });
+
+    it('Shallowclone', () => {
+      const a = new BigDate();
+      const b = shallowclone(a);
+      assert.notStrictEqual(a, b);
+      ckEq(a, b);
+      b.setMinutes(b.getMinutes() + 1);
+      assertUneq(a, b);
+    });
+
+    it('Deepclone', () => {
+      const a = new BigDate();
+      const b = deepclone(a);
+      assert.notStrictEqual(a, b);
+      ckEq(a, b);
+      b.setMinutes(b.getMinutes() + 1);
+      assertUneq(a, b);
+    });
+  });
+});


### PR DESCRIPTION
Introduce a new class BigDate that can store timestamps at arbitrary
precision and measures time at the nanosecond precision.

CoralogixLogger and messageFormatTechnical are updated to use those
higher precision time stamps.

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues


Thanks for contributing!
